### PR TITLE
Block SMS queue for blocked numbers and bulk-expire pending messages

### DIFF
--- a/src/Twilio/Classes/BidxTwilioSMS.php
+++ b/src/Twilio/Classes/BidxTwilioSMS.php
@@ -193,6 +193,16 @@ class BidxTwilioSMS {
 	 * @return  void
 	 */
 	public function send($number, $message, $extra = array()) {
+		$num = $number;
+		if (strlen($num) > 10) {
+			$num = substr($num, 1);
+		}
+		$sql = sprintf("SELECT 1 FROM far_sms_unsub_log WHERE sms_unsub_number = '%s' LIMIT 1", $this->database->escape('1' . $num));
+		$blocked = $this->database->get_results($sql);
+		if (!empty($blocked)) {
+			return;
+		}
+
 		$values = array(
 			'sms_direction' => self::get_numeric_direction(self::DIRECTION_OUTBOUND),
 			'sms_number'    => $number,
@@ -312,19 +322,36 @@ class BidxTwilioSMS {
 		$this->database->update('far_sms_log', $values, $where, 1);
 	}
 
+	private function expire_all_blocked_pending_messages(array $blocked) {
+		if (empty($blocked)) {
+			return;
+		}
+
+		$blockedNums = array_map(function ($b) {
+			return substr($b, 1);
+		}, $blocked);
+
+		$allNums = array_unique(array_merge($blocked, $blockedNums));
+		$escaped = array_map(function ($n) {
+			return '"' . $this->database->escape($n) . '"';
+		}, $allNums);
+		$inClause = implode(',', $escaped);
+
+		$sql = sprintf(
+			'UPDATE far_sms_log SET sms_status = "%s" WHERE sms_status = "%s" AND sms_direction = "0" AND sms_number IN (%s)',
+			self::STATUS_SENDING_FAILED,
+			self::STATUS_PENDING,
+			$inClause
+		);
+		$this->database->query($sql);
+	}
+
 	/**
 	 * Sends all pending messages waiting in queue
 	 *
 	 * @return  void
 	 */
 	private function send_pending_messages() {
-	
-		$sql = 'SELECT * FROM far_sms_log WHERE sms_status = "%s" LIMIT %d';
-		$sql = sprintf($sql, self::STATUS_PENDING, self::PER_LINE_LIMIT * count($this->lines));
-	
-		$messages = $this->database->get_results($sql);
-
-
 		$sql = 'SELECT distinct sms_unsub_number FROM far_sms_unsub_log';
 		$blockedRec = $this->database->get_results($sql);
 		$blocked = [];
@@ -332,6 +359,13 @@ class BidxTwilioSMS {
 			$blocked = array_column($blockedRec,"sms_unsub_number");
 		}
 
+		if (!empty($blocked)) {
+			$this->expire_all_blocked_pending_messages($blocked);
+		}
+
+		$sql = 'SELECT * FROM far_sms_log WHERE sms_status = "%s" AND sms_direction = "0" LIMIT %d';
+		$sql = sprintf($sql, self::STATUS_PENDING, self::PER_LINE_LIMIT * count($this->lines));
+		$messages = $this->database->get_results($sql);
 
 		foreach ($messages as $message) {
 			try {
@@ -407,7 +441,7 @@ class BidxTwilioSMS {
 				$sql = sprintf($sql, $columns, $values);
 				$this->database->query($sql);
 
-				$this->expire_blocked_message($message);
+				$this->expire_all_blocked_pending_messages([substr($num, 1)]);
 				$this->add_blacklist_crm_note($message['sms_number'], $reason);
 				throw new \Exception(sprintf('The message cannot be sent because the user(%s) has opted out or invalid contact. :' .$e->getCode(), $message['sms_number']));
 
@@ -490,9 +524,7 @@ class BidxTwilioSMS {
 					$sql = sprintf($sql, $columns, $values);
 					$this->database->query($sql);
 
-					if(!empty($message['sms_id'])){
-						$this->expire_blocked_message($message);
-					}
+					$this->expire_all_blocked_pending_messages(['1' . $num]);
 					$this->add_blacklist_crm_note($message['sms_number'], $reason);
 					throw new \Exception(sprintf('The message cannot be sent because the user(%s) has opted out. :' .$e->getCode(), $message['sms_number']));
 

--- a/src/Twilio/Classes/BidxTwilioSMSLaravel.php
+++ b/src/Twilio/Classes/BidxTwilioSMSLaravel.php
@@ -201,6 +201,14 @@ class BidxTwilioSMSLaravel
 	 */
 	public function send($number, $message, $extra = array())
 	{
+		$num = $number;
+		if (strlen($num) > 10) {
+			$num = substr($num, 1);
+		}
+		if (SmsUnsub::where('sms_unsub_number', '1' . $num)->exists()) {
+			return;
+		}
+
 		$values = array(
 			'sms_direction' => self::get_numeric_direction(self::DIRECTION_OUTBOUND),
 			'sms_number'    => $number,
@@ -338,6 +346,28 @@ class BidxTwilioSMSLaravel
 			->update($values);
 	}
 
+	private function expire_all_blocked_pending_messages(array $blocked)
+	{
+		if (empty($blocked)) {
+			return;
+		}
+
+		$blockedNums = array_map(function ($b) {
+			return substr($b, 1);
+		}, $blocked);
+
+		$elevenDigit = $blocked;
+		$tenDigit = $blockedNums;
+
+		SmsLog::where('sms_status', self::STATUS_PENDING)
+			->where('sms_direction', '0')
+			->where(function ($query) use ($elevenDigit, $tenDigit) {
+				$query->whereIn('sms_number', $elevenDigit)
+					->orWhereIn('sms_number', $tenDigit);
+			})
+			->update(['sms_status' => self::STATUS_SENDING_FAILED]);
+	}
+
 	/**
 	 * Sends all pending messages waiting in queue
 	 *
@@ -345,14 +375,20 @@ class BidxTwilioSMSLaravel
 	 */
 	private function send_pending_messages()
 	{
+		$blocked = SmsUnsub::distinct()
+			->pluck('sms_unsub_number')
+			->toArray();
+
+		if (!empty($blocked)) {
+			$this->expire_all_blocked_pending_messages($blocked);
+		}
+
 		$messages = SmsLog::where('sms_status', self::STATUS_PENDING)
+			->where('sms_direction', '0')
 			->limit(self::PER_LINE_LIMIT * count($this->lines))
 			->get()->toArray();
 
 		if (!empty($messages)) {
-			$blocked = SmsUnsub::distinct()
-				->pluck('sms_unsub_number')
-				->toArray();
 			foreach ($messages as $message) {
 				try {
 					$this->send_message($message, $blocked);
@@ -417,13 +453,12 @@ class BidxTwilioSMSLaravel
 				}
 
 			SmsUnsub::create($values);
-				$this->expire_blocked_message($message);
+				$this->expire_all_blocked_pending_messages(['1' . $num]);
 				$this->add_blacklist_crm_note($message['sms_number'], $values['sms_unsub_reason']);
 				throw new \Exception(sprintf('The message cannot be sent because the user(%s) has opted out or invalid contact. :' . $e->getCode(), $message['sms_number']));
 			} else {
 				throw new \Exception(sprintf('Error sending SMS to number %s using line %s. Error message: %s and code: %s ', $message['sms_number'], $line, $e->getMessage(), $e->getCode()));
 			}
-			throw new ApiException(sprintf('Error sending SMS to number %s using line %s. Error message: %s', $message['sms_number'], $line, $e->getMessage()));
 		}
 		$this->record_sent_message($message, $resp);
 	}
@@ -484,11 +519,9 @@ class BidxTwilioSMSLaravel
 				}
 
 			SmsUnsub::create($values);
-				if(!empty($message['sms_id'])){
-					$this->expire_blocked_message($message);
-				}
-				$this->add_blacklist_crm_note($message['sms_number'], $values['sms_unsub_reason']);
-				throw new \Exception(sprintf('The message cannot be sent because the user(%s) has opted out or invalid contact. :' . $e->getCode(), $message['sms_number']));
+					$this->expire_all_blocked_pending_messages(['1' . $num]);
+					$this->add_blacklist_crm_note($message['sms_number'], $values['sms_unsub_reason']);
+					throw new \Exception(sprintf('The message cannot be sent because the user(%s) has opted out or invalid contact. :' . $e->getCode(), $message['sms_number']));
 			} else {
 				throw new \Exception(sprintf('Error sending SMS to number %s using line %s.Error code: %s and message: %s ', $message['sms_number'], $line, $e->getMessage(), $e->getCode(), $e->getMessage()));
 			}


### PR DESCRIPTION
# Fixes repeated daily SMS sync errors for blocked numbers

Blocked/opted-out phone numbers were generating the same error notification every cron run because:
1. `send()` never checked the block list before queuing new messages
2. `expire_blocked_message()` only expired the single current message, not all pending messages for that number
3. New messages kept entering the queue for blocked numbers from CRM campaigns

### Changes (applied to both `BidxTwilioSMS.php` and `BidxTwilioSMSLaravel.php`):

- **`send()`** now checks the unsub list before queuing — silently skips blocked numbers
- **`send_pending_messages()`** bulk-expires all pending messages for blocked numbers before fetching the send batch
- **New method `expire_all_blocked_pending_messages()`** handles bulk expiration, matching both 10-digit and 11-digit number formats
- When Twilio returns error 21610/21211, expire ALL pending messages for that number (not just the current one)
- Added `sms_direction = "0"` filter to pending message queries (only process outbound)

### Human Review Checklist

**Critical items:**
- [ ] Verify number format handling: blocked list stores 11-digit (`16744444444`), but `sms_number` in queue could be 10 or 11 digits. The new method generates both variants to match.
- [ ] Confirm `send()` silently dropping blocked numbers is desired behavior (no error, no log entry)
- [ ] Check that adding `sms_direction = "0"` filter doesn't break anything (previously would have included inbound messages in pending query)
- [ ] SQL escaping in `BidxTwilioSMS.php` line 200 uses `$this->database->escape()` — verify this is safe

**Minor items:**
- [ ] Removed unreachable dead code (line 426 in Laravel version)
- [ ] Indentation inconsistency in Laravel `send_instant_sms` error handler (extra tabs)

### Testing Notes
⚠️ **No automated tests included.** Changes involve database queries and Twilio API interactions that require live environment testing. Recommend testing in staging with:
1. A known blocked number in `far_sms_unsub_log`
2. Pending messages for that number in `far_sms_log`
3. Run SMS sync cron and verify no errors appear for the blocked number

---

**Link to Devin run:** https://app.devin.ai/sessions/949ce3c51d024d17835350e040ed3d74  
**Requested by:** @phoenixwade

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-php/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified